### PR TITLE
Max out number of processes on erl startup

### DIFF
--- a/lib/scripts/watchdog.sh.eex
+++ b/lib/scripts/watchdog.sh.eex
@@ -24,7 +24,7 @@ fi
 touch $alive # ensure existence
 
 # start in an erlang VM
-cmd="erl -boot $dir/boot/start -config $dir/boot/sys -env ERL_LIBS $dir/lib"
+cmd="erl -boot $dir/boot/start -config $dir/boot/sys -env ERL_LIBS $dir/lib +P 134217727"
 cmd="$cmd -name ${app}_at_${name}@127.0.0.1 -setcookie $cookie -noshell"
 
 echo "$(date) Running: $cmd" >> $log


### PR DESCRIPTION
We were crashing with a Too many processes error. This should fix it, for the time being.
