### PR TITLE
Add flag :skip_version_check to skip the check_erts_versions step for…

### DIFF
--- a/lib/bottler/release.ex
+++ b/lib/bottler/release.ex
@@ -19,7 +19,7 @@ defmodule Bottler.Release do
     :ok = H.cmd "MIX_ENV=#{env} mix deps.get"
     :ok = H.cmd "MIX_ENV=#{env} mix compile"
 
-    if env == "prod", do: H.check_erts_versions(config)
+    if env == "prod" && not(config[:skip_version_check]), do: H.check_erts_versions(config)
 
     L.info "Generating release tar.gz ..."
     File.rm_rf! "rel"


### PR DESCRIPTION
… prod on Bottler.Release